### PR TITLE
(PIE-1086) Add option to use token auth

### DIFF
--- a/TA-puppet-alert-actions/README/ta_puppet_alert_actions_account.conf.spec
+++ b/TA-puppet-alert-actions/README/ta_puppet_alert_actions_account.conf.spec
@@ -1,3 +1,4 @@
 [<name>]
 username = 
 password = 
+pe_token = 

--- a/TA-puppet-alert-actions/appserver/static/js/build/globalConfig.json
+++ b/TA-puppet-alert-actions/appserver/static/js/build/globalConfig.json
@@ -1,297 +1,305 @@
 {
-    "meta": {
-        "name": "TA-puppet-alert-actions",
-        "displayName": "Puppet Alert Actions",
-        "version": "0.6.0",
-        "apiVersion": "3.0.0",
-        "restRoot": "TA_puppet_alert_actions"
+    "meta":{
+       "name":"TA-puppet-alert-actions",
+       "displayName":"Puppet Alert Actions",
+       "version":"0.6.0",
+       "apiVersion":"3.0.0",
+       "restRoot":"TA_puppet_alert_actions"
     },
-    "pages": {
-        "configuration": {
-            "title": "Configuration",
-            "description": "Set up your add-on",
-            "tabs": [
-                {
-                    "name": "account",
-                    "title": "Account",
-                    "table": {
-                        "header": [
+    "pages":{
+       "configuration":{
+          "title":"Configuration",
+          "description":"Set up your add-on",
+          "tabs":[
+             {
+                "name":"account",
+                "title":"Account",
+                "table":{
+                   "header":[
+                      {
+                         "field":"name",
+                         "label":"Account name"
+                      },
+                      {
+                         "field":"username",
+                         "label":"Username"
+                      }
+                   ],
+                   "actions":[
+                      "edit",
+                      "delete",
+                      "clone"
+                   ]
+                },
+                "entity":[
+                   {
+                      "field":"name",
+                      "label":"Account name",
+                      "type":"text",
+                      "required":true,
+                      "help":"Enter a unique name for this account.",
+                      "validators":[
+                         {
+                            "type":"string",
+                            "minLength":1,
+                            "maxLength":50,
+                            "errorMsg":"Length of Account name should be between 1 and 50"
+                         },
+                         {
+                            "type":"regex",
+                            "pattern":"^[a-zA-Z]\\w*$",
+                            "errorMsg":"Account name must start with a letter and followed by alphabetic letters, digits or underscores."
+                         }
+                      ]
+                   },
+                   {
+                      "field":"username",
+                      "label":"Username",
+                      "type":"text",
+                      "required":true,
+                      "help":"Enter the username for this account.",
+                      "options":{
+                         "placeholder":"Enter the username here"
+                      },
+                      "validators":[
+                         {
+                            "type":"string",
+                            "minLength":1,
+                            "maxLength":200,
+                            "errorMsg":"Length of username should be between 1 and 200"
+                         }
+                      ]
+                   },
+                   {
+                      "field":"password",
+                      "label":"Password",
+                      "type":"text",
+                      "encrypted":true,
+                      "required":true,
+                      "help":"Enter the password or PE RBAC token for this account.",
+                      "validators":[
+                         {
+                            "type":"string",
+                            "minLength":1,
+                            "maxLength":8192,
+                            "errorMsg":"Length of password should be between 1 and 8192"
+                         }
+                      ]
+                   },
+                   {
+                     "field":"pe_token",
+                     "label":"PE Token",
+                     "type":"checkbox",
+                     "help": "Check this box if you provided a PE RBAC token instead of a password.",
+                     "required":false,
+                     "defaultValue": 0
+                   }
+                ]
+             },
+             {
+                "name":"logging",
+                "title":"Logging",
+                "entity":[
+                   {
+                      "field":"loglevel",
+                      "label":"Log level",
+                      "type":"singleSelect",
+                      "options":{
+                         "disableSearch":true,
+                         "autoCompleteFields":[
                             {
-                                "field": "name",
-                                "label": "Account name"
+                               "label":"DEBUG",
+                               "value":"DEBUG"
                             },
                             {
-                                "field": "username",
-                                "label": "Username"
+                               "label":"INFO",
+                               "value":"INFO"
+                            },
+                            {
+                               "label":"WARNING",
+                               "value":"WARNING"
+                            },
+                            {
+                               "label":"ERROR",
+                               "value":"ERROR"
+                            },
+                            {
+                               "label":"CRITICAL",
+                               "value":"CRITICAL"
                             }
-                        ],
-                        "actions": [
-                            "edit",
-                            "delete",
-                            "clone"
-                        ]
-                    },
-                    "entity": [
-                        {
-                            "field": "name",
-                            "label": "Account name",
-                            "type": "text",
-                            "required": true,
-                            "help": "Enter a unique name for this account.",
-                            "validators": [
-                                {
-                                    "type": "string",
-                                    "minLength": 1,
-                                    "maxLength": 50,
-                                    "errorMsg": "Length of Account name should be between 1 and 50"
-                                },
-                                {
-                                    "type": "regex",
-                                    "pattern": "^[a-zA-Z]\\w*$",
-                                    "errorMsg": "Account name must start with a letter and followed by alphabetic letters, digits or underscores."
-                                }
-                            ]
-                        },
-                        {
-                            "field": "username",
-                            "label": "Username",
-                            "type": "text",
-                            "required": true,
-                            "help": "Enter the username for this account.",
-                            "options": {
-                                "placeholder": "Enter the username here"
-                            },
-                            "validators": [
-                                {
-                                    "type": "string",
-                                    "minLength": 1,
-                                    "maxLength": 200,
-                                    "errorMsg": "Length of username should be between 1 and 200"
-                                }
-                            ]
-                        },
-                        {
-                            "field": "password",
-                            "label": "Password",
-                            "type": "text",
-                            "encrypted": true,
-                            "required": true,
-                            "help": "Enter the password for this account.",
-                            "validators": [
-                                {
-                                    "type": "string",
-                                    "minLength": 1,
-                                    "maxLength": 8192,
-                                    "errorMsg": "Length of password should be between 1 and 8192"
-                                }
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "name": "logging",
-                    "title": "Logging",
-                    "entity": [
-                        {
-                            "field": "loglevel",
-                            "label": "Log level",
-                            "type": "singleSelect",
-                            "options": {
-                                "disableSearch": true,
-                                "autoCompleteFields": [
-                                    {
-                                        "label": "DEBUG",
-                                        "value": "DEBUG"
-                                    },
-                                    {
-                                        "label": "INFO",
-                                        "value": "INFO"
-                                    },
-                                    {
-                                        "label": "WARNING",
-                                        "value": "WARNING"
-                                    },
-                                    {
-                                        "label": "ERROR",
-                                        "value": "ERROR"
-                                    },
-                                    {
-                                        "label": "CRITICAL",
-                                        "value": "CRITICAL"
-                                    }
-                                ]
-                            },
-                            "defaultValue": "INFO"
-                        }
-                    ]
-                },
-                {
-                    "name": "additional_parameters",
-                    "title": "Add-on Settings",
-                    "entity": [
-                        {
-                            "field": "puppet_enterprise_console",
-                            "label": "Puppet Enterprise Console",
-                            "type": "text",
-                            "help": "URL to access the Puppet Enterprise console",
-                            "required": true,
-                            "defaultValue": "https://puppet.company.lan",
-                            "validators": [
-                                {
-                                    "type": "string",
-                                    "minLength": 0,
-                                    "maxLength": 8192,
-                                    "errorMsg": "Max length of text input is 8192"
-                                }
-                            ]
-                        },
-                        {
-                            "field": "puppet_default_user",
-                            "label": "User",
-                            "type": "text",
-                            "help": "Account name from Global Accounts to use by default",
-                            "required": true,
-                            "defaultValue": "",
-                            "validators": [
-                                {
-                                    "type": "string",
-                                    "minLength": 0,
-                                    "maxLength": 8192,
-                                    "errorMsg": "Max length of text input is 8192"
-                                }
-                            ]
-                        },
-                        {
-                            "field": "splunk_hec_url",
-                            "label": "Splunk HEC URL",
-                            "type": "text",
-                            "help": "",
-                            "required": true,
-                            "defaultValue": "https://splunk.company.lan:8088/services/collector",
-                            "validators": [
-                                {
-                                    "type": "string",
-                                    "minLength": 0,
-                                    "maxLength": 8192,
-                                    "errorMsg": "Max length of text input is 8192"
-                                }
-                            ]
-                        },
-                        {
-                            "field": "splunk_hec_token",
-                            "label": "Splunk HEC Token",
-                            "type": "text",
-                            "help": "Token from HEC configured with puppet:summary or puppet:detailed sourcetype",
-                            "required": true,
-                            "defaultValue": "",
-                            "validators": [
-                                {
-                                    "type": "string",
-                                    "minLength": 0,
-                                    "maxLength": 8192,
-                                    "errorMsg": "Max length of text input is 8192"
-                                }
-                            ]
-                        },
-                        {
-                            "field": "bolt_user",
-                            "label": "Bolt User",
-                            "type": "text",
-                            "help": "Account name from Global Accounts to use by default for Bolt Actions",
-                            "required": false,
-                            "defaultValue": "",
-                            "validators": [
-                                {
-                                    "type": "string",
-                                    "minLength": 0,
-                                    "maxLength": 8192,
-                                    "errorMsg": "Max length of text input is 8192"
-                                }
-                            ]
-                        },
-                        {
-                            "field": "puppet_action_hec_token",
-                            "label": "Action HEC Token",
-                            "type": "text",
-                            "help": "Provide token if using dedicated HEC to track the actions of this add-on",
-                            "required": false,
-                            "defaultValue": "",
-                            "validators": [
-                                {
-                                    "type": "string",
-                                    "minLength": 0,
-                                    "maxLength": 8192,
-                                    "errorMsg": "Max length of text input is 8192"
-                                }
-                            ]
-                        },
-                        {
-                            "field": "puppet_bolt_server",
-                            "label": "Orch. Services URL",
-                            "type": "text",
-                            "help": "Puppet Enterprise Orchestrator URL (derived from PE Console by default)",
-                            "required": false,
-                            "defaultValue": "",
-                            "validators": [
-                                {
-                                    "type": "string",
-                                    "minLength": 0,
-                                    "maxLength": 8192,
-                                    "errorMsg": "Max length of text input is 8192"
-                                }
-                            ]
-                        },
-                        {
-                            "field": "puppet_db_url",
-                            "label": "PuppetDB URL",
-                            "type": "text",
-                            "help": "URL to access PuppetDB (derived from PE Console by default)",
-                            "required": false,
-                            "defaultValue": "",
-                            "validators": [
-                                {
-                                    "type": "string",
-                                    "minLength": 0,
-                                    "maxLength": 8192,
-                                    "errorMsg": "Max length of text input is 8192"
-                                }
-                            ]
-                        },
-                        {
-                            "field": "timeout",
-                            "label": "Timeout",
-                            "type": "text",
-                            "help": "Maximum time any action should take in seconds",
-                            "required": false,
-                            "defaultValue": "",
-                            "validators": [
-                                {
-                                    "type": "string",
-                                    "minLength": 0,
-                                    "maxLength": 8192,
-                                    "errorMsg": "Max length of text input is 8192"
-                                }
-                            ]
-                        },
-                        {
-                            "field": "pe_console",
-                            "label": "PE Installation",
-                            "type": "text",
-                            "help": "Hostname of PE Installation - puppet.company.lan or pe_console value from splunk_hec module",
-                            "required": false,
-                            "defaultValue": "",
-                            "validators": [
-                                {
-                                    "type": "string",
-                                    "minLength": 0,
-                                    "maxLength": 8192,
-                                    "errorMsg": "Max length of text input is 8192"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ]
-        }
+                         ]
+                      },
+                      "defaultValue":"INFO"
+                   }
+                ]
+             },
+             {
+                "name":"additional_parameters",
+                "title":"Add-on Settings",
+                "entity":[
+                   {
+                      "field":"puppet_enterprise_console",
+                      "label":"Puppet Enterprise Console",
+                      "type":"text",
+                      "help":"URL to access the Puppet Enterprise console",
+                      "required":true,
+                      "defaultValue":"https://puppet.company.lan",
+                      "validators":[
+                         {
+                            "type":"string",
+                            "minLength":0,
+                            "maxLength":8192,
+                            "errorMsg":"Max length of text input is 8192"
+                         }
+                      ]
+                   },
+                   {
+                      "field":"splunk_hec_url",
+                      "label":"Splunk HEC URL",
+                      "type":"text",
+                      "help":"",
+                      "required":true,
+                      "defaultValue":"https://splunk.company.lan:8088/services/collector",
+                      "validators":[
+                         {
+                            "type":"string",
+                            "minLength":0,
+                            "maxLength":8192,
+                            "errorMsg":"Max length of text input is 8192"
+                         }
+                      ]
+                   },
+                   {
+                      "field":"splunk_hec_token",
+                      "label":"Splunk HEC Token",
+                      "type":"text",
+                      "help":"Token from HEC configured with puppet:summary or puppet:detailed sourcetype",
+                      "required":true,
+                      "defaultValue":"",
+                      "validators":[
+                         {
+                            "type":"string",
+                            "minLength":0,
+                            "maxLength":8192,
+                            "errorMsg":"Max length of text input is 8192"
+                         }
+                      ]
+                   },
+                   {
+                      "field":"puppet_default_user",
+                      "label":"User",
+                      "type":"text",
+                      "help":"Account name from Global Accounts to use by default",
+                      "required":true,
+                      "defaultValue":"",
+                      "validators":[
+                         {
+                            "type":"string",
+                            "minLength":0,
+                            "maxLength":8192,
+                            "errorMsg":"Max length of text input is 8192"
+                         }
+                      ]
+                   },
+                   {
+                      "field":"bolt_user",
+                      "label":"Bolt User",
+                      "type":"text",
+                      "help":"Account name from Global Accounts to use by default for Bolt Actions",
+                      "required":false,
+                      "defaultValue":"",
+                      "validators":[
+                         {
+                            "type":"string",
+                            "minLength":0,
+                            "maxLength":8192,
+                            "errorMsg":"Max length of text input is 8192"
+                         }
+                      ]
+                   },
+                   {
+                      "field":"puppet_action_hec_token",
+                      "label":"Action HEC Token",
+                      "type":"text",
+                      "help":"Provide token if using dedicated HEC to track the actions of this add-on",
+                      "required":false,
+                      "defaultValue":"",
+                      "validators":[
+                         {
+                            "type":"string",
+                            "minLength":0,
+                            "maxLength":8192,
+                            "errorMsg":"Max length of text input is 8192"
+                         }
+                      ]
+                   },
+                   {
+                      "field":"puppet_bolt_server",
+                      "label":"Orch. Services URL",
+                      "type":"text",
+                      "help":"Puppet Enterprise Orchestrator URL (derived from PE Console by default)",
+                      "required":false,
+                      "defaultValue":"",
+                      "validators":[
+                         {
+                            "type":"string",
+                            "minLength":0,
+                            "maxLength":8192,
+                            "errorMsg":"Max length of text input is 8192"
+                         }
+                      ]
+                   },
+                   {
+                      "field":"puppet_db_url",
+                      "label":"PuppetDB URL",
+                      "type":"text",
+                      "help":"URL to access PuppetDB (derived from PE Console by default)",
+                      "required":false,
+                      "defaultValue":"",
+                      "validators":[
+                         {
+                            "type":"string",
+                            "minLength":0,
+                            "maxLength":8192,
+                            "errorMsg":"Max length of text input is 8192"
+                         }
+                      ]
+                   },
+                   {
+                      "field":"timeout",
+                      "label":"Timeout",
+                      "type":"text",
+                      "help":"Maximum time any action should take in seconds",
+                      "required":false,
+                      "defaultValue":"",
+                      "validators":[
+                         {
+                            "type":"string",
+                            "minLength":0,
+                            "maxLength":8192,
+                            "errorMsg":"Max length of text input is 8192"
+                         }
+                      ]
+                   },
+                   {
+                      "field":"pe_console",
+                      "label":"PE Installation",
+                      "type":"text",
+                      "help":"Hostname of PE Installation - puppet.company.lan or pe_console value from splunk_hec module",
+                      "required":false,
+                      "defaultValue":"",
+                      "validators":[
+                         {
+                            "type":"string",
+                            "minLength":0,
+                            "maxLength":8192,
+                            "errorMsg":"Max length of text input is 8192"
+                         }
+                      ]
+                   }
+                ]
+             }
+          ]
+       }
     }
 }

--- a/TA-puppet-alert-actions/bin/TA_puppet_alert_actions_rh_account.py
+++ b/TA-puppet-alert-actions/bin/TA_puppet_alert_actions_rh_account.py
@@ -33,6 +33,13 @@ fields = [
             min_len=1, 
             max_len=8192, 
         )
+    ),
+    field.RestField(
+        'pe_token',
+        required=False,
+        encrypted=False,
+        default=0,
+        validator=None
     )
 ]
 model = RestModel(fields, name=None)

--- a/TA-puppet-alert-actions/bin/ta_puppet_alert_actions/modalert_puppet_generate_detailed_report_helper.py
+++ b/TA-puppet-alert-actions/bin/ta_puppet_alert_actions/modalert_puppet_generate_detailed_report_helper.py
@@ -129,6 +129,10 @@ def process_event(helper, *args, **kwargs):
     puppet_read_user = puppet_read_account["username"]
     puppet_read_user_pass = puppet_read_account["password"]
 
+    # Check if users are utilizing RBAC tokens instead of Passwords.
+    # This setting is passed in as a string; so we are converting it to boolean here:
+    rbac_token = bool(int(puppet_read_account["pe_token"]))
+
     helper.log_debug("username={}".format(puppet_read_user))
     
     # load the rest of the settings
@@ -169,6 +173,7 @@ def process_event(helper, *args, **kwargs):
     alert['global']['splunk_hec_url'] = splunk_hec_url
     alert['global']['splunk_hec_token'] = splunk_hec_token
     alert['global']['timeout'] = timeout
+    alert['global']['pe_token'] = rbac_token
     
     # we're using the notnone function to ensure we always have a value, even if it's duplicate
     # we call it with notnone(default_value, possible_none, helper) - default_value is returned if possible_none is None

--- a/TA-puppet-alert-actions/bin/ta_puppet_alert_actions/modalert_puppet_run_task_helper.py
+++ b/TA-puppet-alert-actions/bin/ta_puppet_alert_actions/modalert_puppet_run_task_helper.py
@@ -147,6 +147,10 @@ def process_event(helper, *args, **kwargs):
     puppet_bolt_user = puppet_bolt_account["username"]
     puppet_bolt_user_pass = puppet_bolt_account["password"]
 
+    # Check if users are utilizing RBAC tokens instead of Passwords.
+    # This setting is passed in as a string; so we are converting it to boolean here:
+    rbac_token = bool(int(puppet_bolt_account["pe_token"]))
+
     helper.log_debug("username={}".format(puppet_bolt_user))
 
     # load the rest of the settings
@@ -222,6 +226,7 @@ def process_event(helper, *args, **kwargs):
     alert['global']['puppet_action_hec_token'] = notnone(splunk_hec_token, puppet_action_hec_token, helper)
     alert['global']['timeout'] = timeout
     alert['global']['pe_console'] = pe_console
+    alert['global']['pe_token'] = rbac_token
 
     # Load the alert specific settings that are really the task we're running
     alert['param']['bolt_target'] = bolt_target

--- a/TA-puppet-alert-actions/bin/ta_puppet_alert_actions/puppet_bolt_action.py
+++ b/TA-puppet-alert-actions/bin/ta_puppet_alert_actions/puppet_bolt_action.py
@@ -77,7 +77,11 @@ def run_bolt_task(alert, helper):
   except Exception as e:
     helper.log_error("Timeout must be an integer, '{}' was provided instead".format(task_timeout))
 
-  auth_token = pie.rbac.genauthtoken(bolt_user,bolt_user_pass,'TA-puppet-alert-actions',rbac_url, timeout=token_lifetime)
+ # Check if the user is configured with an RBAC token or Password:
+  if alert['global']['pe_token']:
+    auth_token = bolt_user_pass
+  else:
+    auth_token = pie.rbac.genauthtoken(bolt_user,bolt_user_pass,'TA-puppet-alert-actions',rbac_url, timeout=token_lifetime)
 
   # note: parameters is expected as a text string, not json, so in sample alert json must be represented as:
   # "task_parameters": "{ \"name\": \"ntpd\", \"action\": \"status\"}"

--- a/TA-puppet-alert-actions/bin/ta_puppet_alert_actions/puppet_report_generation.py
+++ b/TA-puppet-alert-actions/bin/ta_puppet_alert_actions/puppet_report_generation.py
@@ -103,9 +103,12 @@ def run_report_generation(alert, transaction_uuids, helper):
 
   # all our data / settin parsing is done, lets do work
 
-  helper.log_debug("Attempting to get token for {}".format(pdbuser))
-
-  auth_token = pie.rbac.genauthtoken(pdbuser,pdbpass,'TA-puppet-alert-actions',rbac_url, lifetime)
+  # Check if the user is configured with an RBAC token or Password:
+  if alert['global']['pe_token']:
+    auth_token = pdbpass
+  else:
+    helper.log_debug("Attempting to get token for {}".format(pdbuser))
+    auth_token = pie.rbac.genauthtoken(pdbuser,pdbpass,'TA-puppet-alert-actions',rbac_url, lifetime)
 
   helper.log_info("Attempting to generate and submit {} detailed reports".format(len(transaction_uuids)))
   for uuid in transaction_uuids:


### PR DESCRIPTION
# Summary

This commit add a new checkbox field for each configured user to specify if you are using an RBAC token or Password.

# Detailed Description

  * Changes to `appserver/static/js/build/globalConfig.json` to add the **PE Token** checkbox.
  * Added `pe_token` field to `README/ta_puppet_alert_actions_account.conf.spec`.
  * Changes to the following in `bin/`:
    * Added a REST field in `TA_puppet_alert_actions_rh_account.py`.
    * The `modalert_puppet_run_task_helper.py` script will grab the `pe_token` parameter and pass it as a Boolean to `puppet_bolt_action.py`.
      * When `pe_token` is configured `puppet_bolt_action.py` will treat the password field as the token value instead.
    * The `modalert_puppet_generate_detailed_report_helper.py` script will grab the `pe_token` parameter and pass it as a Boolean to `puppet_bolt_action.py`.
      * When `pe_token` is configured `puppet_report_generation.py` will treat the password field as the token value instead.