### PR TITLE
(PIE-1155) Input script for available actions

### DIFF
--- a/TA-puppet-alert-actions/bin/inputs/orchestrator_actions.py
+++ b/TA-puppet-alert-actions/bin/inputs/orchestrator_actions.py
@@ -1,0 +1,135 @@
+# $SPUNK_HOME/etc/apps/TA-puppet-alert-actions/bin/inputs/orchestrator_actions.py
+#
+import sys
+import os
+#
+#
+# If Splunk was installed in a custom location, change SPLUNK_APPS to the path where apps are installed.
+APP_NAME = 'TA-puppet-alert-actions'
+if os.name == 'nt':
+  SPLUNK_APPS = 'C:\Program Files\Splunk\etc\/apps\/'
+else:
+  SPLUNK_APPS = '/opt/splunk/etc/apps'
+PIE_LIB = os.path.join(SPLUNK_APPS, APP_NAME, 'bin', 'ta_puppet_alert_actions')
+AOB_LIB = os.path.join(SPLUNK_APPS, APP_NAME, 'bin', 'ta_puppet_alert_actions', 'aob_py3')
+#
+#
+# Here we modify the system path for Python to find the required helper libs.
+try:
+  PATHS = [PIE_LIB,AOB_LIB]
+  for path in PATHS:
+    sys.path.append(path)
+  import pie
+  from splunk_aoblib.setup_util import Setup_Util
+except Exception as e:
+  sys.stderr.write("TA-puppet-alert-actions: Failed to import required libs - {}".format(e))
+#
+#
+# Define Splunk URI and session key.
+uri = "https://localhost:8089"
+session_key = sys.stdin.readline().strip()
+#
+#
+# Configure the AOB Helper (Setup_Util) to access the settings configured in the add-on.
+# This also takes a custom logger as a third attribute. Currently we are utilizing the default behaviour of input scripts logging stderr to splunkd.log.
+helper = Setup_Util(uri,session_key)
+#
+# 
+# Build a dictionary of the custom inputs utilized to retrieve the available actions.
+inputs = {}
+inputs['hec_token'] = helper.get_customized_setting("splunk_hec_token")
+inputs['hec_url'] = helper.get_customized_setting("splunk_hec_url")
+inputs['pe_console'] = helper.get_customized_setting("puppet_enterprise_console")
+inputs['timeout'] = helper.get_customized_setting("timeout")
+#
+#
+# Check if there is a configured timeout.
+if inputs['timeout'] is not None and inputs['timeout'] is not '':
+  timeout = inputs['timeout']
+else:
+  timeout = 360
+#
+#
+try:
+  #
+  # Retrieve any user accounts configured within the add-on.
+  config_file = os.path.join(SPLUNK_APPS, APP_NAME, 'local/ta_puppet_alert_actions_account.conf')
+  account_list = pie.util.list_accounts(config_file)
+  for user in account_list:
+    inputs['account'] = helper.get_credential_by_username(user)
+    #
+    # Check if the user is configured with an RBAC token or Password:
+    _token = bool(int(inputs['account']['pe_token']))
+    if _token:
+      token = inputs['account']['password']
+    else:
+      user = inputs['account']['username']
+      upass = inputs['account']['password']
+      endpoints = pie.util.getendpoints(inputs['pe_console'])
+      rbac_url = endpoints['rbac']
+      token = pie.rbac.genauthtoken(user,upass,'TA-puppet-alert-actions',rbac_url,timeout)
+    try:
+      #
+      # Build event message for available Tasks by user.
+      tasklist = pie.bolt.get_tasklist(inputs['pe_console'],token)
+      for task in tasklist:
+        t_id = task['id']
+        task_parameter = pie.bolt.get_actionparams(t_id,token)
+        tmessage = {
+          'permitted': task['permitted'],
+          'task_meta': None,
+          'task_name': task['name'],
+          'task_params': [],
+          'user': user,
+        }
+        #
+        # Add any task parameters to the event message.
+        try:
+          tmessage['task_meta'] = task_parameter['metadata']['parameters']
+          for param in tmessage['task_meta']:
+            tmessage['task_params'].append(param)
+          #
+          # Post Tasks via HEC endpoint
+          try:
+            host = inputs['pe_console'].replace("https://", "")
+            hec_url = inputs['hec_url']
+            hec_token = inputs['hec_token']
+            post_tasks = pie.hec.post_action(tmessage,host,hec_url,hec_token)
+          except Exception as e:
+            sys.stderr.write("TA-puppet-alert-actions: Failed to post task data to Splunk - {}".format(e))
+        except:
+          pass
+      #
+      # Build event message for available Plans by user.
+      planlist = pie.bolt.get_planlist(inputs['pe_console'],token)
+      for plan in planlist:
+        p_id = plan['id']
+        plan_parameter = pie.bolt.get_actionparams(p_id,token)
+        pmessage = {
+          'permitted': plan['permitted'],
+          'plan_meta': None,
+          'plan_name': plan['name'],
+          'plan_params': [],
+          'user': user,
+        }
+        #
+        # Add any plan parameters to the event.
+        try:
+          pmessage['plan_meta'] = plan_parameter['metadata']['parameters']
+          for param in pmessage['plan_meta']:
+            pmessage['plan_params'].append(param)
+          #
+          # Post Plans via HEC endpoint
+          try:
+            host = inputs['pe_console'].replace("https://", "")
+            hec_url = inputs['hec_url']
+            hec_token = inputs['hec_token']
+            post_plans = pie.hec.post_action(pmessage,host,hec_url,hec_token)
+          except Exception as e:
+            sys.stderr.write("TA-puppet-alert-actions: Failed to post plan data to Splunk - {}".format(e))
+        except:
+          pass
+    except Exception as e:
+      sys.stderr.write("TA-puppet-alert-actions: Failed to build event message - {}".format(e))
+except Exception as e:
+  sys.stderr.write("TA-puppet-alert-actions: Empty Account List - {}".format(e))

--- a/TA-puppet-alert-actions/bin/ta_puppet_alert_actions/pie/bolt.py
+++ b/TA-puppet-alert-actions/bin/ta_puppet_alert_actions/pie/bolt.py
@@ -82,6 +82,54 @@ def reqplan(plan, token, environment, url, parameters=None):
 
   return post_plan('{}/command/plan_run'.format(url), req, headers)
 
+# Given URL and RBAC Token:
+# Retrieve list of available tasks
+def get_tasklist(url, token):
+  endpoint = "8143/orchestrator/v1/tasks"
+  uri = '{}:{}'.format(url,endpoint)
+  headers = {'X-Authentication': token}
+  try:
+    r = requests.get(uri, headers=headers, verify=False)
+  except:
+    print('Unexpected error:', sys.exc_info()[0])
+    raise
+ 
+  if r.status_code != 200:
+    raise ValueError('Unable to retrieve list of available Tasks:', uri, r.status_code, r.text)
+  
+  return json.loads(r.text)['items']
+
+# Given URL and RBAC Token:
+# Retrieve list of available plans
+def get_planlist(url, token):
+  endpoint = "8143/orchestrator/v1/plans"
+  uri = '{}:{}'.format(url,endpoint)
+  headers = {'X-Authentication': token}
+  try:
+    r = requests.get(uri, headers=headers, verify=False)
+  except:
+    print('Unexpected error:', sys.exc_info()[0])
+    raise
+ 
+  if r.status_code != 200:
+    raise ValueError('Unable to retrieve list of available Plans:', uri, r.status_code, r.text)
+  
+  return json.loads(r.text)['items']
+
+# Given Task or Plan ID and RBAC Token:
+# Retrieve any available parameters
+def get_actionparams(action_id, token):
+  headers = {'X-Authentication': token}
+  try:
+    r = requests.get(action_id, headers=headers, verify=False)
+  except:
+    print('Unexpected error:', sys.exc_info()[0])
+    raise
+ 
+  if r.status_code == 200:
+    return json.loads(r.text)  
+  else:
+    pass
 
 # Get job state
 # given a joburl and token, return state

--- a/TA-puppet-alert-actions/bin/ta_puppet_alert_actions/pie/util.py
+++ b/TA-puppet-alert-actions/bin/ta_puppet_alert_actions/pie/util.py
@@ -1,3 +1,6 @@
+import configparser
+import sys
+
 try:
   from urllib.parse import urlparse
 except ImportError:
@@ -20,3 +23,20 @@ def getendpoints (uri, useproxy=False):
   endpoints['console_hostname'] = hostname
 
   return endpoints
+
+# Given a path to a config_file:
+# Return a list of usernames from the config file.
+def list_accounts(config_file):
+  config = configparser.ConfigParser()
+  config.read(config_file)
+  userlist = []
+
+  for stanza in config:
+    if config.has_option(stanza,"username"):
+      setting = config[stanza]['username']
+      userlist.append(setting)
+
+  if userlist == []:
+    sys.stderr.write("TA-puppet-alert-actions: Unable to find any accounts when parsing {}".format(config_file))
+  else:
+    return userlist

--- a/TA-puppet-alert-actions/default/inputs.conf
+++ b/TA-puppet-alert-actions/default/inputs.conf
@@ -1,0 +1,5 @@
+[script://./bin/inputs/orchestrator_actions.py]
+disabled = 0
+interval = 3600
+passAuth = splunk-system-user
+python.version = python3

--- a/TA-puppet-alert-actions/default/macros.conf
+++ b/TA-puppet-alert-actions/default/macros.conf
@@ -1,0 +1,9 @@
+[puppet_index]
+# add the name of your index here if it is not main index
+definition = ""
+iseval = 0
+
+[puppet_actions_index]
+# add the name of your index here if it is not main index=puppet_index
+definition = `puppet_index`
+iseval = 0


### PR DESCRIPTION
# Summary

This commit adds a configured custom scripted input to query a PE installation for available Tasks and Plans.

# Detailed Description

### Added:

The custom input script utilizes the AOB helper functions to build an event message containing detailed information on available tasks and plans per configured user. The inputs configuration file currently enables the input on install running on an hourly schedule (this can be changed by users). The macros configuration specifies which internal Splunk index to post data to.

  * `/bin/inputs/orchestrator_actions.py`
  * `default/inputs.conf`
  * `default/macros.conf`

The script also utilizes our internal PIE library for posting the aforementioned event message to the `puppet_actions_index` over the HEC endpoint.

The new functions in `bolt.py` hit the tasks and plans endpoints as well as retrieve any available metadata (params, description, etc). There is also a function added to `util.py` to parse a config file for a list of users configured in this add-on.

  * `bin/ta_puppet_alert_actions/pie/bolt.py`
  * `/bin/ta_puppet_alert_actions/pie/util.py`
