### PR TITLE
(PIE-1157) Dynamic HTML Inputs

### DIFF
--- a/TA-puppet-alert-actions/README/alert_actions.conf.spec
+++ b/TA-puppet-alert-actions/README/alert_actions.conf.spec
@@ -1,27 +1,62 @@
-
 [puppet_generate_detailed_report]
 python.version = python3
-param.puppet_enterprise_console = <string> Puppet Enterprise Console.
-param.puppet_default_user = <string> User.
-param.splunk_hec_url = <string> Splunk HEC URL.
-param.splunk_hec_token = <string> Splunk HEC Token.
-param.puppet_action_hec_token = <string> Action HEC Token.
-param.puppet_db_url = <string> PuppetDB URL.
-param.timeout = <string> Timeout.
-param.pe_console = <string> PE Installation.
+param.puppet_enterprise_console = <string>
+* Alternate PE Console URL
+param.puppet_db_url = <string>
+* Alternate PuppetDB URL
+param.puppet_user = <string>
+* Alternate RBAC user to run the task.
+param.timeout = <string>
+* Alternate timeout.
+param.splunk_hec_url = <string>
+* Alternate Splunk HEC URL.
+param.puppet_action_hec_token = <string>
+* Alternate Action HEC Token.
 
 [puppet_run_task]
 python.version = python3
-param.bolt_target = <string> Host. It's a required parameter. It's default value is $result.host$.
-param.task_name = <string> Task. It's a required parameter.
-param.task_parameters = <string> Task Parameters.
-param.puppet_environment = <string> Puppet Environment. It's a required parameter. It's default value is production.
-param.puppet_enterprise_console = <string> Puppet Enterprise Console.
-param.bolt_user = <string> Bolt User.
-param.pe_console = <string> PE Installation.
-param.puppet_bolt_server = <string> Orch. Services URL.
-param.puppet_db_url = <string> PuppetDB URL.
-param.timeout = <string> Timeout.
-param.splunk_hec_url = <string> Splunk HEC URL.
-param.puppet_action_hec_token = <string> Action HEC Token.
+param.action_target = <string>
+* Hostname of the target to run the task on.
+* Default value is "$result.host$"
+* (required)
+param.task_name = <string>
+* Task Name
+* (required)
+param.task_parameters = <string>
+* Task Parameters
+param.puppet_environment = <string>
+* Puppet environment where the task is located.
+* Default value is production.
+* (required)
+param.puppet_user = <string>
+* Alternate RBAC user to run the task.
+param.puppet_orch_server = <string>
+* Alternate URL for the Orchestrator Server.
+param.timeout = <string>
+* Alternate timeout.
+param.splunk_hec_url = <string>
+* Alternate Splunk HEC URL.
+param.puppet_action_hec_token = <string>
+* Alternate Action HEC Token.
 
+[puppet_run_plan]
+python.version = python3
+param.plan_name = <string>
+* Plan Name
+* (required)
+param.plan_parameters = <string>
+* Plan Parameters
+param.puppet_environment = <string>
+* Puppet environment where the plan is located.
+* Default value is production.
+* (required)
+param.puppet_user = <string>
+* Alternate RBAC user to run the plan.
+param.puppet_orch_server = <string> Orch. Services URL.
+* Alternate URL for the Orchestrator Server.
+param.timeout = <string>
+* Alternate timeout.
+param.splunk_hec_url = <string>
+* Alternate Splunk HEC URL.
+param.puppet_action_hec_token = <string>
+* Alternate Action HEC Token

--- a/TA-puppet-alert-actions/default/alert_actions.conf
+++ b/TA-puppet-alert-actions/default/alert_actions.conf
@@ -1,4 +1,3 @@
-
 [puppet_generate_detailed_report]
 python.version = python3
 description = Generates a puppet:detailed event from a puppet:summary event
@@ -6,32 +5,20 @@ label = Generate detailed Puppet report
 is_custom = 1
 payload_format = json
 icon_path = alert_puppet_generate_detailed_report.png
-param.puppet_enterprise_console = 
-param.puppet_default_user = 
-param.splunk_hec_url = 
-param.splunk_hec_token = 
-param.puppet_action_hec_token = 
-param.puppet_db_url = 
-param.timeout = 
-param.pe_console = 
 
 [puppet_run_task]
 python.version = python3
-description = Run a Bolt Task on the events host with Puppet Enterprise
-label = Run a Bolt Task
+description = Run a Puppet Task on the events host with Puppet Enterprise
+label = Run a Puppet Task
 is_custom = 1
 payload_format = json
 icon_path = alert_puppet_run_task.png
-param.bolt_target = $result.host$
-param.task_name = 
-param.task_parameters = 
-param.puppet_environment = production
-param.puppet_enterprise_console = 
-param.bolt_user = 
-param.pe_console = 
-param.puppet_bolt_server = 
-param.puppet_db_url = 
-param.timeout = 
-param.splunk_hec_url = 
-param.puppet_action_hec_token = 
 
+[puppet_run_plan]
+python.version = python3
+maxtime = 1h
+description = Run a Puppet Plan with Puppet Enterprise
+label = Run a Puppet Plan
+is_custom = 1
+payload_format = json
+icon_path = alert_puppet_run_task.png

--- a/TA-puppet-alert-actions/default/data/ui/alerts/puppet_generate_detailed_report.html
+++ b/TA-puppet-alert-actions/default/data/ui/alerts/puppet_generate_detailed_report.html
@@ -1,74 +1,26 @@
-<form class="form-horizontal form-complex">
-<div class="control-group">
-	<label class="control-label" for="puppet_generate_detailed_report_puppet_enterprise_console">Puppet Enterprise Console  </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_generate_detailed_report.param.puppet_enterprise_console" id="puppet_generate_detailed_report_puppet_enterprise_console"/>
-                <span class="help-block"> 
-                    Override which PE Console to use
-                </span>
-    </div>
-</div>
-<div class="control-group">
-	<label class="control-label" for="puppet_generate_detailed_report_puppet_default_user">User  </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_generate_detailed_report.param.puppet_default_user" id="puppet_generate_detailed_report_puppet_default_user"/>
-                <span class="help-block"> 
-                    Override which User account to use
-                </span>
-    </div>
-</div>
-<div class="control-group">
-	<label class="control-label" for="puppet_generate_detailed_report_splunk_hec_url">Splunk HEC URL  </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_generate_detailed_report.param.splunk_hec_url" id="puppet_generate_detailed_report_splunk_hec_url"/>
-                <span class="help-block"> 
-                    Override which Splunk HEC URL to use
-                </span>
-    </div>
-</div>
-<div class="control-group">
-	<label class="control-label" for="puppet_generate_detailed_report_splunk_hec_token">Splunk HEC Token  </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_generate_detailed_report.param.splunk_hec_token" id="puppet_generate_detailed_report_splunk_hec_token"/>
-                <span class="help-block"> 
-                    Override which Splunk HEC Token to use
-                </span>
-    </div>
-</div>
-<div class="control-group">
-	<label class="control-label" for="puppet_generate_detailed_report_puppet_action_hec_token">Action HEC Token  </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_generate_detailed_report.param.puppet_action_hec_token" id="puppet_generate_detailed_report_puppet_action_hec_token"/>
-                <span class="help-block"> 
-                    Override which Action HEC token to use
-                </span>
-    </div>
-</div>
-<div class="control-group">
-	<label class="control-label" for="puppet_generate_detailed_report_puppet_db_url">PuppetDB URL  </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_generate_detailed_report.param.puppet_db_url" id="puppet_generate_detailed_report_puppet_db_url"/>
-                <span class="help-block"> 
-                    Override which PuppetDB URL to use
-                </span>
-    </div>
-</div>
-<div class="control-group">
-	<label class="control-label" for="puppet_generate_detailed_report_timeout">Timeout  </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_generate_detailed_report.param.timeout" id="puppet_generate_detailed_report_timeout"/>
-                <span class="help-block"> 
-                    Override timeout settings for this alert
-                </span>
-    </div>
-</div>
-<div class="control-group">
-	<label class="control-label" for="puppet_generate_detailed_report_pe_console">PE Installation  </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_generate_detailed_report.param.pe_console" id="puppet_generate_detailed_report_pe_console"/>
-                <span class="help-block"> 
-                    Override default PE Installation (pe_console value used in splunk_hec module)
-                </span>
-    </div>
-</div>
+<form>
+    <splunk-control-group label="Puppet Enterprise Console" help="Override the default PE Console URL">
+      <splunk-text-area name="action.puppet_generate_detailed_report.param.puppet_enterprise_console" id="puppet_generate_detailed_report_puppet_enterprise_console">
+      </splunk-text-area>
+    </splunk-control-group>
+    <splunk-control-group label="PuppetDB URL" help="Override the default PuppetDB URL">
+      <splunk-text-input name="action.puppet_generate_detailed_report.param.puppet_db_url" id="puppet_generate_detailed_report_puppet_db_url">
+      </splunk-text-input>
+    </splunk-control-group>
+    <splunk-control-group label="Alternate Puppet User" help="Override default Puppet User">
+      <splunk-text-input name="action.puppet_generate_detailed_report.param.puppet_user" id="puppet_generate_detailed_report_puppet_user">
+      </splunk-text-input>
+    </splunk-control-group>
+    <splunk-control-group label="Timeout" help="Override the default Timeout">
+      <splunk-text-input name="action.puppet_generate_detailed_report.param.timeout" id="puppet_generate_detailed_report_timeout">
+      </splunk-text-input>
+    </splunk-control-group>
+    <splunk-control-group label="Splunk HEC URL" help="Override the default Splunk HEC URL">
+      <splunk-text-input name="action.puppet_generate_detailed_report.param.splunk_hec_url" id="puppet_generate_detailed_report_splunk_hec_url">
+      </splunk-text-input>
+    </splunk-control-group>
+    <splunk-control-group label="Action HEC Token" help="Override the default Action HEC Token">
+      <splunk-text-input name="action.puppet_generate_detailed_report.param.puppet_action_hec_token" id="puppet_generate_detailed_report_puppet_action_hec_token">
+      </splunk-text-input>
+    </splunk-control-group>
 </form>

--- a/TA-puppet-alert-actions/default/data/ui/alerts/puppet_run_plan.html
+++ b/TA-puppet-alert-actions/default/data/ui/alerts/puppet_run_plan.html
@@ -1,0 +1,37 @@
+<form>
+  <splunk-control-group label="Plan">
+    <splunk-search-dropdown name="action.puppet_run_plan.param.plan_name"
+      search="`puppet_actions_index` sourcetype=puppet:action | dedup plan_name | sort plan_name | table plan_name"
+      value-field="plan_name" label-field="plan_name"
+      allow-custom-value
+    />
+  </splunk-control-group>
+  <splunk-control-group label="Plan Parameters" help="Provide parameters as unescaped json: {&quot;target&quot; : &quot;$result.host$&quot;, &quot;service&quot;: &quot;puppet&quot;}">
+    <splunk-text-area name="action.puppet_run_plan.param.plan_parameters" id="puppet_run_plan_plan_parameters">
+    </splunk-text-area>
+  </splunk-control-group>
+  <splunk-control-group label="Puppet Environment" help="The Puppet environment that the Plan is located in.">
+    <splunk-text-input name="action.puppet_run_plan.param.puppet_environment" id="puppet_run_plan_puppet_environment" value="production">
+    </splunk-text-input>
+  </splunk-control-group>
+  <splunk-control-group label="Alternate Puppet User" help="Override default Puppet User">
+    <splunk-text-input name="action.puppet_run_plan.param.puppet_user" id="puppet_run_plan_puppet_user">
+    </splunk-text-input>
+  </splunk-control-group>
+  <splunk-control-group label="Orchestrator Services URL" help="Override the default Orchestrator URL">
+    <splunk-text-input name="action.puppet_run_plan.param.puppet_orch_server" id="puppet_run_plan_puppet_orch_server">
+    </splunk-text-input>
+  </splunk-control-group>
+  <splunk-control-group label="Timeout" help="Override the default Timeout">
+    <splunk-text-input name="action.puppet_run_plan.param.timeout" id="puppet_run_plan_timeout">
+    </splunk-text-input>
+  </splunk-control-group>
+  <splunk-control-group label="Splunk HEC URL" help="Override the default Splunk HEC URL">
+    <splunk-text-input name="action.puppet_run_plan.param.splunk_hec_url" id="puppet_run_plan_splunk_hec_url">
+    </splunk-text-input>
+  </splunk-control-group>
+  <splunk-control-group label="Action HEC Token" help="Override the default Action HEC Token">
+    <splunk-text-input name="action.puppet_run_plan.param.puppet_action_hec_token" id="puppet_run_plan_puppet_action_hec_token">
+    </splunk-text-input>
+  </splunk-control-group>
+</form>

--- a/TA-puppet-alert-actions/default/data/ui/alerts/puppet_run_task.html
+++ b/TA-puppet-alert-actions/default/data/ui/alerts/puppet_run_task.html
@@ -1,107 +1,41 @@
-<form class="form-horizontal form-complex">
-<div class="control-group">
-	<label class="control-label" for="puppet_run_task_bolt_target">Host <span class="required">*</span> </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_run_task.param.bolt_target" id="puppet_run_task_bolt_target"/>
-    </div>
-</div>
-<div class="control-group">
-	<label class="control-label" for="puppet_run_task_task_name">Task <span class="required">*</span> </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_run_task.param.task_name" id="puppet_run_task_task_name"/>
-                <span class="help-block"> 
-                    Name of task to be run, such as: service::linux
-                </span>
-    </div>
-</div>
-<div class="control-group">
-	<label class="control-label" for="puppet_run_task_task_parameters">Task Parameters  </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_run_task.param.task_parameters" id="puppet_run_task_task_parameters"/>
-                <span class="help-block"> 
-                    Provide parameters as unescaped json: {"name" : "puppet", "action": "status"}
-                </span>
-    </div>
-</div>
-<div class="control-group">
-	<label class="control-label" for="puppet_run_task_puppet_environment">Puppet Environment <span class="required">*</span> </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_run_task.param.puppet_environment" id="puppet_run_task_puppet_environment"/>
-                <span class="help-block"> 
-                    Puppet environment that task is located in
-                </span>
-    </div>
-</div>
-<div class="control-group">
-	<label class="control-label" for="puppet_run_task_puppet_enterprise_console">Puppet Enterprise Console  </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_run_task.param.puppet_enterprise_console" id="puppet_run_task_puppet_enterprise_console"/>
-                <span class="help-block"> 
-                    Override default PE Console
-                </span>
-    </div>
-</div>
-<div class="control-group">
-	<label class="control-label" for="puppet_run_task_bolt_user">Bolt User  </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_run_task.param.bolt_user" id="puppet_run_task_bolt_user"/>
-                <span class="help-block"> 
-                    Override default Bolt User
-                </span>
-    </div>
-</div>
-<div class="control-group">
-	<label class="control-label" for="puppet_run_task_pe_console">PE Installation  </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_run_task.param.pe_console" id="puppet_run_task_pe_console"/>
-                <span class="help-block"> 
-                    Override default PE Installation (pe_console value used in splunk_hec module)
-                </span>
-    </div>
-</div>
-<div class="control-group">
-	<label class="control-label" for="puppet_run_task_puppet_bolt_server">Orch. Services URL  </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_run_task.param.puppet_bolt_server" id="puppet_run_task_puppet_bolt_server"/>
-                <span class="help-block"> 
-                    Override default PE Orch URL
-                </span>
-    </div>
-</div>
-<div class="control-group">
-	<label class="control-label" for="puppet_run_task_puppet_db_url">PuppetDB URL  </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_run_task.param.puppet_db_url" id="puppet_run_task_puppet_db_url"/>
-                <span class="help-block"> 
-                    Override default PuppetDB URL
-                </span>
-    </div>
-</div>
-<div class="control-group">
-	<label class="control-label" for="puppet_run_task_timeout">Timeout  </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_run_task.param.timeout" id="puppet_run_task_timeout"/>
-                <span class="help-block"> 
-                    Override default Timeout
-                </span>
-    </div>
-</div>
-<div class="control-group">
-	<label class="control-label" for="puppet_run_task_splunk_hec_url">Splunk HEC URL  </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_run_task.param.splunk_hec_url" id="puppet_run_task_splunk_hec_url"/>
-                <span class="help-block"> 
-                    Override default Splunk HEC URL
-                </span>
-    </div>
-</div>
-<div class="control-group">
-	<label class="control-label" for="puppet_run_task_puppet_action_hec_token">Action HEC Token  </label>
-    <div class="controls">
-	<input type="text" name="action.puppet_run_task.param.puppet_action_hec_token" id="puppet_run_task_puppet_action_hec_token"/>
-                <span class="help-block"> 
-                    Override default Action HEC Token
-                </span>
-    </div>
-</div>
+<form>
+    <splunk-control-group label="Host" help="The hostname of the node to run the Task on.">
+      <splunk-text-input name="action.puppet_run_task.param.action_target" id="puppet_run_task_action_target" value="$result.host$">
+      </splunk-text-input>
+    </splunk-control-group>
+    <splunk-control-group label="Task">
+      <splunk-search-dropdown name="action.puppet_run_task.param.task_name"
+        search="`puppet_actions_index` sourcetype=puppet:action | dedup task_name | sort task_name | table task_name"
+        value-field="task_name" label-field="task_name"
+        allow-custom-value
+      />
+    </splunk-control-group>
+    <splunk-control-group label="Task Parameters" help="Provide parameters as unescaped json: {&quot;name&quot; : &quot;puppet&quot;, &quot;action&quot;: &quot;status&quot;}">
+      <splunk-text-area name="action.puppet_run_task.param.task_parameters" id="puppet_run_task_task_parameters">
+      </splunk-text-area>
+    </splunk-control-group>
+    <splunk-control-group label="Puppet Environment" help="The Puppet environment that the Task is located in.">
+      <splunk-text-input name="action.puppet_run_task.param.puppet_environment" id="puppet_run_task_puppet_environment" value="production">
+      </splunk-text-input>
+    </splunk-control-group>
+    <splunk-control-group label="Alternate Puppet User" help="Override default Puppet User">
+      <splunk-text-input name="action.puppet_run_task.param.puppet_user" id="puppet_run_task_puppet_user">
+      </splunk-text-input>
+    </splunk-control-group>
+    <splunk-control-group label="Orchestrator Services URL" help="Override the default Orchestrator URL">
+      <splunk-text-input name="action.puppet_run_task.param.puppet_orch_server" id="puppet_run_task_puppet_orch_server">
+      </splunk-text-input>
+    </splunk-control-group>
+    <splunk-control-group label="Timeout" help="Override the default Timeout">
+      <splunk-text-input name="action.puppet_run_task.param.timeout" id="puppet_run_task_timeout">
+      </splunk-text-input>
+    </splunk-control-group>
+    <splunk-control-group label="Splunk HEC URL" help="Override the default Splunk HEC URL">
+      <splunk-text-input name="action.puppet_run_task.param.splunk_hec_url" id="puppet_run_task_splunk_hec_url">
+      </splunk-text-input>
+    </splunk-control-group>
+    <splunk-control-group label="Action HEC Token" help="Override the default Action HEC Token">
+      <splunk-text-input name="action.puppet_run_task.param.puppet_action_hec_token" id="puppet_run_task_puppet_action_hec_token">
+      </splunk-text-input>
+    </splunk-control-group>
 </form>


### PR DESCRIPTION
# Summary

This commit adds the Run Plan action to the Splunk UI, provides dynamic input for Run Task action, and updates the Detailed Report action.

# Detailed Description

  * Moved default values from `default/alert_actions.conf` to the HTML input files.
    * Added `[puppet_run_plan]` stanza.
  * Updated `README/alert_actions.conf.spec`.
  * Changes in `default/data/ui/alerts`:
    * Added `puppet_run_plan.html` w/ dynamic input for plan name.
    * Updated `puppet_generate_detailed_report.html` for Splunk UI HTML formatting.
    *  Updated `puppet_run_task.html` for Splunk UI HTML formatting w/ dynamic input for task name.