### PR TITLE
(MAINT) Publish releases as GitHub Releases instead of workflow artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-package:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v6
@@ -32,8 +34,11 @@ jobs:
       - name: Package app
         run: slim package output/TA-puppet-alert-orchestrator
 
-      - name: Upload App Build
-        uses: actions/upload-artifact@v7
-        with:
-          name: TA-puppet-alert-orchestrator-${{ steps.version-tag.outputs.version }}
-          path: TA-puppet-alert-orchestrator-*.tar.gz
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ steps.version-tag.outputs.version }} \
+            TA-puppet-alert-orchestrator-*.tar.gz \
+            --title "${{ steps.version-tag.outputs.version }}" \
+            --generate-notes


### PR DESCRIPTION
## Summary

- Workflow artifacts expire after 90 days and require navigating to a specific Actions run to download
- GitHub Releases provide a stable download URL, permanent retention, and a visible release history on the repo home page
- Replaces the \`upload-artifact\` step with \`gh release create\` and grants the job \`contents: write\` so the auto-provided \`GITHUB_TOKEN\` can publish the release
- \`--generate-notes\` auto-populates release notes from merged PRs since the last release (editable in the UI after the fact)
- No PATs or managed secrets required

## Test plan
- [ ] Merge this PR
- [ ] Push a \`v*.*.*\` tag and verify the workflow:
  - [ ] Builds the app
  - [ ] Packages with \`slim\`
  - [ ] Creates a GitHub Release with the \`.tar.gz\` attached
  - [ ] Release notes are auto-generated from PR history